### PR TITLE
feat(comp): add challenge class; add commit check for warning and errors and run tests; exposed H2 in memory for DB access.

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,4 +27,3 @@ fi
 
 echo "[pre-commit] Checks passed. Proceeding with commit."
 exit 0
-

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,7 +17,7 @@ fi
 # Run a fast build check (compile + tests). Adjust as needed.
 echo "[pre-commit] Running Maven tests..."
 MVN_OPTS="-Dbatch.mode=true -Dstyle.color=always"
-mvn -q "${MVN_OPTS}" -DskipTests=false -Dtest=* test
+mvn -q "${MVN_OPTS}" -DskipTests=false -Dtest='**/*Test' test
 MVN_STATUS=$?
 
 if [ $MVN_STATUS -ne 0 ]; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,7 +16,7 @@ fi
 
 # Run a fast build check (compile + tests). Adjust as needed.
 echo "[pre-commit] Running Maven tests..."
-MVN_OPTS="-Dbatch.mode=true -Dstyle.color=always"
+MVN_OPTS="-B -Dstyle.color=always"
 mvn -q "${MVN_OPTS}" -DskipTests=false -Dtest='**/*Test' test
 MVN_STATUS=$?
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# Pre-commit hook: block commit if Maven tests fail.
+# Override: use `git commit --no-verify` to bypass.
+
+# Allow explicit override via env var
+if [ "$GIT_ALLOW_COMMIT" = "1" ]; then
+  echo "[pre-commit] Override detected (GIT_ALLOW_COMMIT=1). Skipping checks."
+  exit 0
+fi
+
+# Ensure Maven is available
+if ! command -v mvn >/dev/null 2>&1; then
+  echo "[pre-commit] Maven (mvn) not found on PATH. Aborting commit." >&2
+  exit 1
+fi
+
+# Run a fast build check (compile + tests). Adjust as needed.
+echo "[pre-commit] Running Maven tests..."
+MVN_OPTS="-Dbatch.mode=true -Dstyle.color=always"
+mvn -q "${MVN_OPTS}" -DskipTests=false -Dtest=* test
+MVN_STATUS=$?
+
+if [ $MVN_STATUS -ne 0 ]; then
+  echo "[pre-commit] Maven tests failed. Fix issues or commit with --no-verify to override." >&2
+  exit 1
+fi
+
+echo "[pre-commit] Checks passed. Proceeding with commit."
+exit 0
+

--- a/.githooks/pre-commit.bat
+++ b/.githooks/pre-commit.bat
@@ -1,0 +1,27 @@
+@echo off
+REM Pre-commit hook for Windows: block commit if Maven tests fail.
+REM Override 1: git commit --no-verify
+REM Override 2: set GIT_ALLOW_COMMIT=1 (env var)
+
+IF "%GIT_ALLOW_COMMIT%"=="1" (
+  echo [pre-commit] Override detected (GIT_ALLOW_COMMIT=1). Skipping checks.
+  EXIT /B 0
+)
+
+where mvn >NUL 2>&1
+IF ERRORLEVEL 1 (
+  echo [pre-commit] Maven (mvn) not found on PATH. Aborting commit.
+  EXIT /B 1
+)
+
+echo [pre-commit] Running Maven tests...
+REM Quiet-ish run, fail on test errors
+mvn -q -DskipTests=false test
+IF ERRORLEVEL 1 (
+  echo [pre-commit] Maven tests failed. Fix issues or commit with --no-verify to override.
+  EXIT /B 1
+)
+
+echo [pre-commit] Checks passed. Proceeding with commit.
+EXIT /B 0
+

--- a/.githooks/pre-commit.bat
+++ b/.githooks/pre-commit.bat
@@ -24,4 +24,3 @@ IF ERRORLEVEL 1 (
 
 echo [pre-commit] Checks passed. Proceeding with commit.
 EXIT /B 0
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        (github.event_name != 'push' || (
+          !contains(github.event.head_commit.message, '[skip ci]') &&
+          !contains(github.event.head_commit.message, '[ci skip]')
+        )) &&
+        (github.event_name != 'pull_request' || (
+          !contains(github.event.pull_request.title, '[skip ci]') &&
+          !contains(github.event.pull_request.body, '[skip ci]') &&
+          !contains(toJSON(github.event.pull_request.labels), 'ci-skip')
+        ))
+      }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Build and run tests
+        run: mvn -B -DskipTests=false verify

--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,10 @@
       <artifactId>spring-boot-starter-log4j2</artifactId>
     </dependency>
 
-    <!-- H2 for dev/test -->
+    <!-- H2 for dev/test: compile scope needed for org.h2.tools.Server in H2ServerConfig -->
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <!-- JSP support (Spring Boot 3 / Jakarta) -->

--- a/scripts/setup-git-hooks.cmd
+++ b/scripts/setup-git-hooks.cmd
@@ -14,4 +14,3 @@ echo [setup] Git hooks configured to use .githooks
 
 echo [setup] You can bypass hooks with: git commit --no-verify
 EXIT /B 0
-

--- a/scripts/setup-git-hooks.cmd
+++ b/scripts/setup-git-hooks.cmd
@@ -1,0 +1,17 @@
+@echo off
+REM Configure local repo to use hooks in .githooks directory.
+REM Run this once per clone.
+
+cd /d "%~dp0.."
+
+git config core.hooksPath .githooks
+IF ERRORLEVEL 1 (
+  echo [setup] Failed to set core.hooksPath. Ensure you are in a Git repo.
+  EXIT /B 1
+)
+
+echo [setup] Git hooks configured to use .githooks
+
+echo [setup] You can bypass hooks with: git commit --no-verify
+EXIT /B 0
+

--- a/src/main/java/me/nickhanson/codeforge/config/H2ServerConfig.java
+++ b/src/main/java/me/nickhanson/codeforge/config/H2ServerConfig.java
@@ -1,0 +1,22 @@
+package me.nickhanson.codeforge.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.h2.tools.Server;
+
+import java.sql.SQLException;
+
+@Configuration
+@ConditionalOnProperty(name = "app.h2.tcp.enabled", havingValue = "true")
+@ConditionalOnClass(Server.class)
+public class H2ServerConfig {
+
+    @Bean(initMethod = "start", destroyMethod = "stop")
+    public Server h2TcpServer() throws SQLException {
+        // Expose in-memory DB to external tools (IntelliJ) via TCP
+        // Connect with: jdbc:h2:tcp://localhost:9092/mem:codeforge_dev
+        return Server.createTcpServer("-tcp", "-tcpPort", "9092");
+    }
+}

--- a/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
+++ b/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
@@ -50,7 +50,7 @@ public class Challenge {
                 ", title='" + title + '\'' +
                 ", difficulty=" + difficulty +
                 ", blurb='" + blurb + '\'' +
-                ", promptMd='" + (promptMd.length() > 20 ? promptMd.substring(0, 20) + "..." : promptMd) + '\'' +
+                ", promptMd='" + (promptMd != null ? (promptMd.length() > 20 ? promptMd.substring(0, 20) + "..." : promptMd) : "null") + '\'' +
                 ", createdAt=" + createdAt +
                 '}';
     }

--- a/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
+++ b/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
@@ -50,8 +50,15 @@ public class Challenge {
                 ", title='" + title + '\'' +
                 ", difficulty=" + difficulty +
                 ", blurb='" + blurb + '\'' +
-                ", promptMd='" + (promptMd != null ? (promptMd.length() > 20 ? promptMd.substring(0, 20) + "..." : promptMd) : "null") + '\'' +
+                ", promptMd='" + formatPromptMd() + '\'' +
                 ", createdAt=" + createdAt +
                 '}';
+    }
+
+    private String formatPromptMd() {
+        if (promptMd == null) {
+            return "null";
+        }
+        return promptMd.length() > 20 ? promptMd.substring(0, 20) + "..." : promptMd;
     }
 }

--- a/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
+++ b/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
@@ -6,12 +6,11 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.Instant;
-import java.lang.SuppressWarnings;
 
 @Entity
 @Table(name = "challenges")
-@SuppressWarnings("JpaDataSourceORMInspection")
 @Getter
+@Setter
 public class Challenge {
 
     @Id
@@ -19,26 +18,21 @@ public class Challenge {
     private Long id;
 
     @Column(nullable = false, unique = true, length = 100)
-    @Setter
     private String title;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    @Setter
     private Difficulty difficulty;
 
     @Column(nullable = false)
-    @Setter
     private String blurb;
 
     @Lob
     @Column(nullable = false)
-    @Setter
     private String promptMd;
 
     @CreationTimestamp
     @Column(updatable = false)
-    @SuppressWarnings("unused")
     private Instant createdAt;
 
     // --- constructors ---

--- a/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
+++ b/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
@@ -2,11 +2,16 @@ package me.nickhanson.codeforge.entity;
 
 import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.time.Instant;
+import java.lang.SuppressWarnings;
 
 @Entity
 @Table(name = "challenges")
+@SuppressWarnings("JpaDataSourceORMInspection")
+@Getter
 public class Challenge {
 
     @Id
@@ -14,21 +19,26 @@ public class Challenge {
     private Long id;
 
     @Column(nullable = false, unique = true, length = 100)
+    @Setter
     private String title;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
+    @Setter
     private Difficulty difficulty;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false)
+    @Setter
     private String blurb;
 
     @Lob
     @Column(nullable = false)
+    @Setter
     private String promptMd;
 
     @CreationTimestamp
     @Column(updatable = false)
+    @SuppressWarnings("unused")
     private Instant createdAt;
 
     // --- constructors ---
@@ -39,18 +49,6 @@ public class Challenge {
         this.blurb = blurb;
         this.promptMd = promptMd;
     }
-
-    // --- getters/setters ---
-    public Long getId() { return id; }
-    public String getTitle() { return title; }
-    public void setTitle(String title) { this.title = title; }
-    public Difficulty getDifficulty() { return difficulty; }
-    public void setDifficulty(Difficulty difficulty) { this.difficulty = difficulty; }
-    public String getBlurb() { return blurb; }
-    public void setBlurb(String blurb) { this.blurb = blurb; }
-    public String getPromptMd() { return promptMd; }
-    public void setPromptMd(String promptMd) { this.promptMd = promptMd; }
-    public Instant getCreatedAt() { return createdAt; }
 
     public String toString() {
         return "Challenge{" +

--- a/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
+++ b/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
@@ -31,7 +31,7 @@ public class Challenge {
     @Column(updatable = false)
     private Instant createdAt;
 
-    // --- ctors ---
+    // --- constructors ---
     protected Challenge() {} // JPA
     public Challenge(String title, Difficulty difficulty, String blurb, String promptMd) {
         this.title = title;
@@ -51,4 +51,15 @@ public class Challenge {
     public String getPromptMd() { return promptMd; }
     public void setPromptMd(String promptMd) { this.promptMd = promptMd; }
     public Instant getCreatedAt() { return createdAt; }
+
+    public String toString() {
+        return "Challenge{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", difficulty=" + difficulty +
+                ", blurb='" + blurb + '\'' +
+                ", promptMd='" + (promptMd.length() > 20 ? promptMd.substring(0, 20) + "..." : promptMd) + '\'' +
+                ", createdAt=" + createdAt +
+                '}';
+    }
 }

--- a/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
+++ b/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
@@ -24,6 +24,7 @@ public class Challenge {
     @Column(nullable = false, length = 20)
     private Difficulty difficulty;
 
+    @Lob
     @Column(nullable = false)
     private String blurb;
 

--- a/src/main/java/me/nickhanson/codeforge/web/ChallengesController.java
+++ b/src/main/java/me/nickhanson/codeforge/web/ChallengesController.java
@@ -43,4 +43,3 @@ public class ChallengesController {
         return "challenges/detail";
     }
 }
-

--- a/src/main/java/me/nickhanson/codeforge/web/ChallengesController.java
+++ b/src/main/java/me/nickhanson/codeforge/web/ChallengesController.java
@@ -1,0 +1,46 @@
+package me.nickhanson.codeforge.web;
+
+import me.nickhanson.codeforge.utilities.ChallengeRepo;
+import me.nickhanson.codeforge.entity.Challenge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/challenges")
+public class ChallengesController {
+    private static final Logger log = LoggerFactory.getLogger(ChallengesController.class);
+    private final ChallengeRepo repo;
+
+    public ChallengesController(ChallengeRepo repo) {
+        this.repo = repo;
+    }
+
+    @GetMapping
+    public String list(Model model) {
+        List<Challenge> all = repo.findAll();
+        log.info("Rendering challenge list, count={}", all.size());
+        model.addAttribute("challenges", all);
+        return "challenges/list";
+    }
+
+    @GetMapping("/{id}")
+    public String detail(@PathVariable Long id, Model model) {
+        Challenge challenge = repo.findById(id).orElseThrow(() -> {
+            log.warn("Challenge not found id={}", id);
+            return new ResponseStatusException(HttpStatus.NOT_FOUND, "Challenge not found");
+        });
+        log.info("Rendering challenge detail id={} title={} difficulty={}", id, challenge.getTitle(), challenge.getDifficulty());
+        model.addAttribute("challenge", challenge);
+        return "challenges/detail";
+    }
+}
+

--- a/src/main/java/me/nickhanson/codeforge/web/HomeController.java
+++ b/src/main/java/me/nickhanson/codeforge/web/HomeController.java
@@ -1,0 +1,17 @@
+package me.nickhanson.codeforge.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+    private static final Logger log = LoggerFactory.getLogger(HomeController.class);
+
+    @GetMapping({"/", "/index"})
+    public String index() {
+        log.info("Rendering home page (JSP)");
+        return "home"; // resolved to /WEB-INF/jsp/home.jsp via application.yml
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,12 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    defer-datasource-initialization: true
   h2:
     console:
       enabled: true
       path: /h2-console
+  mvc:
+    view:
+      prefix: /WEB-INF/jsp/
+      suffix: .jsp

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
     view:
       prefix: /WEB-INF/jsp/
       suffix: .jsp
+app:
+  h2:
+    tcp:
+      enabled: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+INSERT INTO challenges (title, difficulty, blurb, prompt_md)
+VALUES
+  ('Two Sum', 'EASY', 'Find two numbers adding up to target.', 'Given an int array nums and int target, return indices of the two numbers such that they add up to target.'),
+  ('Valid Parentheses', 'EASY', 'Check if parentheses are balanced.', 'Given a string s containing ''()[]{}'', determine if the input string is valid.'),
+  ('Merge Intervals', 'MEDIUM', 'Merge overlapping intervals.', 'Given an array of intervals where intervals[i] = [starti, endi], merge all overlapping intervals.');
+

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -3,4 +3,3 @@ VALUES
   ('Two Sum', 'EASY', 'Find two numbers adding up to target.', 'Given an int array nums and int target, return indices of the two numbers such that they add up to target.'),
   ('Valid Parentheses', 'EASY', 'Check if parentheses are balanced.', 'Given a string s containing ''()[]{}'', determine if the input string is valid.'),
   ('Merge Intervals', 'MEDIUM', 'Merge overlapping intervals.', 'Given an array of intervals where intervals[i] = [starti, endi], merge all overlapping intervals.');
-

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO challenges (title, difficulty, blurb, prompt_md)
+INSERT INTO CHALLENGES (TITLE, DIFFICULTY, BLURB, PROMPT_MD)
 VALUES
   ('Two Sum', 'EASY', 'Find two numbers adding up to target.', 'Given an int array nums and int target, return indices of the two numbers such that they add up to target.'),
   ('Valid Parentheses', 'EASY', 'Check if parentheses are balanced.', 'Given a string s containing ''()[]{}'', determine if the input string is valid.'),

--- a/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
@@ -19,4 +19,3 @@
   <pre style="white-space: pre-wrap;"><c:out value="${challenge.promptMd}"/></pre>
 </body>
 </html>
-

--- a/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
@@ -7,7 +7,7 @@
   <title>Challenge Detail</title>
 </head>
 <body>
-  <p><a href="/">Home</a> | <a href="/challenges">All Challenges</a></p>
+  <p><a href="${pageContext.request.contextPath}/">Home</a> | <a href="${pageContext.request.contextPath}/challenges">All Challenges</a></p>
   <h1><c:out value="${challenge.title}"/></h1>
   <p>
     <strong>Difficulty:</strong> <c:out value="${challenge.difficulty}"/>

--- a/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
@@ -16,7 +16,7 @@
     <strong>Summary:</strong> <c:out value="${challenge.blurb}"/>
   </p>
   <h3>Prompt</h3>
-  <pre style="white-space: pre-wrap;">${challenge.promptMd}</pre>
+  <pre style="white-space: pre-wrap;"><c:out value="${challenge.promptMd}"/></pre>
 </body>
 </html>
 

--- a/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
@@ -1,0 +1,22 @@
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Challenge Detail</title>
+</head>
+<body>
+  <p><a href="/">Home</a> | <a href="/challenges">All Challenges</a></p>
+  <h1><c:out value="${challenge.title}"/></h1>
+  <p>
+    <strong>Difficulty:</strong> <c:out value="${challenge.difficulty}"/>
+  </p>
+  <p>
+    <strong>Summary:</strong> <c:out value="${challenge.blurb}"/>
+  </p>
+  <h3>Prompt</h3>
+  <pre style="white-space: pre-wrap;">${challenge.promptMd}</pre>
+</body>
+</html>
+

--- a/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
@@ -28,7 +28,7 @@
           <c:forEach items="${challenges}" var="ch">
             <tr>
               <td><c:out value="${ch.id}"/></td>
-              <td><a href="/challenges/${ch.id}"><c:out value="${ch.title}"/></a></td>
+              <td><a href="${pageContext.request.contextPath}/challenges/${ch.id}"><c:out value="${ch.title}"/></a></td>
               <td><c:out value="${ch.difficulty}"/></td>
               <td><c:out value="${ch.blurb}"/></td>
             </tr>

--- a/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
@@ -1,0 +1,42 @@
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Challenges</title>
+</head>
+<body>
+  <h1>Challenges</h1>
+  <p><a href="/">Home</a></p>
+
+  <c:choose>
+    <c:when test="${empty challenges}">
+      <p>No challenges available.</p>
+    </c:when>
+    <c:otherwise>
+      <table border="1" cellpadding="6" cellspacing="0">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>Difficulty</th>
+            <th>Blurb</th>
+          </tr>
+        </thead>
+        <tbody>
+          <c:forEach items="${challenges}" var="ch">
+            <tr>
+              <td><c:out value="${ch.id}"/></td>
+              <td><a href="/challenges/${ch.id}"><c:out value="${ch.title}"/></a></td>
+              <td><c:out value="${ch.difficulty}"/></td>
+              <td><c:out value="${ch.blurb}"/></td>
+            </tr>
+          </c:forEach>
+        </tbody>
+      </table>
+    </c:otherwise>
+  </c:choose>
+</body>
+</html>
+

--- a/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
@@ -39,4 +39,3 @@
   </c:choose>
 </body>
 </html>
-

--- a/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
@@ -8,14 +8,14 @@
 </head>
 <body>
   <h1>Challenges</h1>
-  <p><a href="/">Home</a></p>
+  <p><a href="${pageContext.request.contextPath}/">Home</a></p>
 
   <c:choose>
     <c:when test="${empty challenges}">
       <p>No challenges available.</p>
     </c:when>
     <c:otherwise>
-      <table border="1" cellpadding="6" cellspacing="0">
+      <table>
         <thead>
           <tr>
             <th>ID</th>

--- a/src/main/webapp/WEB-INF/jsp/home.jsp
+++ b/src/main/webapp/WEB-INF/jsp/home.jsp
@@ -1,0 +1,19 @@
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CodeForge</title>
+</head>
+<body>
+  <h1>Welcome to CodeForge</h1>
+  <p>This home page is served via JSP (Spring Boot + Tomcat Jasper).</p>
+  <ul>
+    <li><a href="/challenges">Browse Challenges</a></li>
+    <li><a href="/healthz">Health Check</a></li>
+    <li><a href="/h2-console">H2 Console</a> (dev)</li>
+  </ul>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/home.jsp
+++ b/src/main/webapp/WEB-INF/jsp/home.jsp
@@ -11,9 +11,9 @@
   <h1>Welcome to CodeForge</h1>
   <p>This home page is served via JSP (Spring Boot + Tomcat Jasper).</p>
   <ul>
-    <li><a href="/challenges">Browse Challenges</a></li>
-    <li><a href="/healthz">Health Check</a></li>
-    <li><a href="/h2-console">H2 Console</a> (dev)</li>
+    <li><a href="${pageContext.request.contextPath}/challenges">Browse Challenges</a></li>
+    <li><a href="${pageContext.request.contextPath}/healthz">Health Check</a></li>
+    <li><a href="${pageContext.request.contextPath}/h2-console">H2 Console</a> (dev)</li>
   </ul>
 </body>
 </html>

--- a/src/test/java/me/nickhanson/codeforge/utilities/ChallengeRepoTest.java
+++ b/src/test/java/me/nickhanson/codeforge/utilities/ChallengeRepoTest.java
@@ -5,12 +5,14 @@ import me.nickhanson.codeforge.entity.Difficulty;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ActiveProfiles("test")
 class ChallengeRepoTest {
 
     @Autowired

--- a/src/test/java/me/nickhanson/codeforge/web/HomeControllerTest.java
+++ b/src/test/java/me/nickhanson/codeforge/web/HomeControllerTest.java
@@ -1,0 +1,38 @@
+package me.nickhanson.codeforge.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(controllers = HomeController.class)
+class HomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @TestConfiguration
+    static class ViewResolverConfig {
+        @Bean
+        InternalResourceViewResolver defaultViewResolver() {
+            InternalResourceViewResolver resolver = new InternalResourceViewResolver();
+            resolver.setPrefix("/WEB-INF/jsp/");
+            resolver.setSuffix(".jsp");
+            return resolver;
+        }
+    }
+
+    @Test
+    void home_shouldRenderHomeJsp() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("home"));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,10 +6,13 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate.format_sql: true
+  sql:
+    init:
+      mode: never
   h2:
     console:
       enabled: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,3 +17,7 @@ spring:
     console:
       enabled: true
       path: /h2-console
+app:
+  h2:
+    tcp:
+      enabled: false


### PR DESCRIPTION
This pull request introduces a full-stack implementation for listing and viewing coding challenges in a Spring Boot web application with JSP views. It includes new controllers, views, database configuration, and supporting infrastructure for development and testing. The most important changes are grouped below.

### Web Layer: Controllers and Views

* Added `HomeController` and `ChallengesController` to handle home page and challenge listing/detail routes, respectively (`src/main/java/me/nickhanson/codeforge/web/HomeController.java`, `src/main/java/me/nickhanson/codeforge/web/ChallengesController.java`). [[1]](diffhunk://#diff-28ae91930b615b9b181600ccf6fc9d65aea0821b0f9a2e9989a2bf861840a90dR1-R17) [[2]](diffhunk://#diff-fea59d3d99ff791aa116d1fe4273c59acb6e3b0dc3fc2884b690b438d79be9d9R1-R46)
* Created JSP views for the home page, challenge list, and challenge detail (`src/main/webapp/WEB-INF/jsp/home.jsp`, `src/main/webapp/WEB-INF/jsp/challenges/list.jsp`, `src/main/webapp/WEB-INF/jsp/challenges/detail.jsp`). [[1]](diffhunk://#diff-49c12b0592bdb430bf2ae1cecd260a5145d008f01d7557539b1571b2040b42cbR1-R19) [[2]](diffhunk://#diff-9b34c63431b1fc120d65140bc74d61f61c593ac9de74f154a5c29996c944a654R1-R42) [[3]](diffhunk://#diff-6b563999a3b4b97f0c09a031ab30da08d4af4ed419597f445b250d657a12f29cR1-R22)

### Database and Entity Configuration

* Added initial challenge data via `data.sql` and updated H2 configuration to support TCP connections and JSP view resolution (`src/main/resources/data.sql`, `src/main/resources/application.yml`). [[1]](diffhunk://#diff-7f148b1d99361fa9fe2a88f2009f50179de9cc7f46aea5240411c21289d2f36aR1-R6) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR10-R22)
* Introduced `H2ServerConfig` to expose the H2 in-memory database via TCP for development tooling (`src/main/java/me/nickhanson/codeforge/config/H2ServerConfig.java`).
* Updated `Challenge` entity: enabled Lombok for getters/setters, improved annotations, and replaced explicit getter/setter methods with Lombok. Added a `toString()` method for logging/debugging (`src/main/java/me/nickhanson/codeforge/entity/Challenge.java`). [[1]](diffhunk://#diff-ff824fae0a91812d02de3885c56995159cea908c818b182cfa85448829f06c9eR5-R44) [[2]](diffhunk://#diff-ff824fae0a91812d02de3885c56995159cea908c818b182cfa85448829f06c9eL43-R62)

### Development and CI Tooling

* Added pre-commit hooks for both Unix and Windows to enforce Maven test pass before commit (`.githooks/pre-commit`, `.githooks/pre-commit.bat`). [[1]](diffhunk://#diff-87320095d7c4f39eed5d8f3866b512eb910e4eec8e7926faaeef6a53ab786fcbR1-R30) [[2]](diffhunk://#diff-44a7044f5c607b156764070673084d248d6dc28641daac4edeb37ac37d6d3d05R1-R27)
* Provided a script to set up the custom git hooks directory (`scripts/setup-git-hooks.cmd`).
* Introduced a GitHub Actions CI workflow to build and test on every push and PR, with support for `[skip ci]` and label-based skipping (`.github/workflows/ci.yml`).

### Testing and Environment

* Added a web layer test for the home controller, including view resolver configuration (`src/test/java/me/nickhanson/codeforge/web/HomeControllerTest.java`).
* Updated test profile and JPA/H2 settings for isolation and performance (`src/test/resources/application-test.yml`, `src/test/java/me/nickhanson/codeforge/utilities/ChallengeRepoTest.java`). [[1]](diffhunk://#diff-3d17508f6ed3b2bf957c725741cde10edeb229b40b8c3cecf57e7dc5ce78ede6L9-R23) [[2]](diffhunk://#diff-8c7e38465825cf13a8d5ce00335ca98bd349861639c710063a6d61fde09aeb9eR8-R15)

### Dependency and Build Configuration

* Changed H2 dependency scope from `runtime` to default (compile) in `pom.xml` to allow direct usage in configuration classes (`pom.xml`).