### PR TITLE
feat(challenges): add CRUD to challenges; add global exception handler; add pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,9 +15,9 @@ if ! command -v mvn >/dev/null 2>&1; then
 fi
 
 # Run a fast build check (compile + tests). Adjust as needed.
+# Note: Do NOT quote grouped flags; pass them directly so Maven parses them as separate options.
 echo "[pre-commit] Running Maven tests..."
-MVN_OPTS="-B -Dstyle.color=always"
-mvn -q "${MVN_OPTS}" -DskipTests=false -Dtest='**/*Test' test
+mvn -q -B -Dstyle.color=always -DskipTests=false -Dtest='**/*Test' test
 MVN_STATUS=$?
 
 if [ $MVN_STATUS -ne 0 ]; then

--- a/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
+++ b/src/main/java/me/nickhanson/codeforge/entity/Challenge.java
@@ -7,37 +7,77 @@ import lombok.Setter;
 
 import java.time.Instant;
 
+/**
+ * Entity class representing a Challenge in the system.
+ * This class is mapped to the "challenges" table in the database.
+ */
 @Entity
 @Table(name = "challenges")
 @Getter
 @Setter
 public class Challenge {
 
+    /**
+     * The unique identifier for the challenge.
+     * Auto-generated using the IDENTITY strategy.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /**
+     * The title of the challenge.
+     * Must be unique, not null, and have a maximum length of 100 characters.
+     */
     @Column(nullable = false, unique = true, length = 100)
     private String title;
 
+    /**
+     * The difficulty level of the challenge.
+     * Stored as a string and cannot be null.
+     */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private Difficulty difficulty;
 
+    /**
+     * A short description or summary of the challenge.
+     * Stored as a large object (LOB) and cannot be null.
+     */
     @Lob
     @Column(nullable = false)
     private String blurb;
 
+    /**
+     * The full prompt for the challenge in Markdown format.
+     * Stored as a large object (LOB) and cannot be null.
+     */
     @Lob
     @Column(nullable = false)
     private String promptMd;
 
+    /**
+     * The timestamp indicating when the challenge was created.
+     * Automatically set when the entity is persisted and cannot be updated.
+     */
     @CreationTimestamp
     @Column(updatable = false)
     private Instant createdAt;
 
-    // --- constructors ---
+    /**
+     * Default constructor required by JPA.
+     * Protected to prevent direct instantiation.
+     */
     protected Challenge() {} // JPA
+
+    /**
+     * Constructs a new Challenge with the specified title, difficulty, blurb, and prompt.
+     *
+     * @param title     The title of the challenge.
+     * @param difficulty The difficulty level of the challenge.
+     * @param blurb     A short description of the challenge.
+     * @param promptMd  The full prompt in Markdown format.
+     */
     public Challenge(String title, Difficulty difficulty, String blurb, String promptMd) {
         this.title = title;
         this.difficulty = difficulty;
@@ -45,6 +85,13 @@ public class Challenge {
         this.promptMd = promptMd;
     }
 
+    /**
+     * Returns a string representation of the Challenge object.
+     * Includes the id, title, difficulty, blurb, a truncated version of promptMd, and createdAt.
+     *
+     * @return A string representation of the Challenge.
+     */
+    @Override
     public String toString() {
         return "Challenge{" +
                 "id=" + id +
@@ -56,6 +103,12 @@ public class Challenge {
                 '}';
     }
 
+    /**
+     * Formats the prompt Markdown for display.
+     * If the prompt is longer than 20 characters, it truncates and appends "...".
+     *
+     * @return A formatted string representation of the prompt.
+     */
     private String formatPromptMd() {
         if (promptMd == null) {
             return "null";

--- a/src/main/java/me/nickhanson/codeforge/service/ChallengeService.java
+++ b/src/main/java/me/nickhanson/codeforge/service/ChallengeService.java
@@ -1,0 +1,117 @@
+package me.nickhanson.codeforge.service;
+
+import me.nickhanson.codeforge.entity.Challenge;
+import me.nickhanson.codeforge.utilities.ChallengeRepo;
+import me.nickhanson.codeforge.web.ChallengeForm;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * Service class for managing Challenge entities.
+ * Provides methods for CRUD operations and business logic.
+ */
+@Service
+public class ChallengeService {
+    private final ChallengeRepo repo;
+
+    /**
+     * Constructor for ChallengeService.
+     *
+     * @param repo The repository used for accessing Challenge data.
+     */
+    public ChallengeService(ChallengeRepo repo) {
+        this.repo = repo;
+    }
+
+    /**
+     * Retrieves a paginated list of challenges, optionally filtered by difficulty.
+     *
+     * @param difficulty The difficulty level to filter by (can be null for no filtering).
+     * @param pageable   The pagination and sorting information.
+     * @return A page of challenges matching the criteria.
+     */
+    public org.springframework.data.domain.Page<Challenge> listChallenges(me.nickhanson.codeforge.entity.Difficulty difficulty, org.springframework.data.domain.Pageable pageable) {
+        if (difficulty == null) {
+            return repo.findAll(pageable);
+        }
+        return repo.findByDifficulty(difficulty, pageable);
+    }
+
+    /**
+     * Retrieves a challenge by its unique identifier.
+     *
+     * @param id The unique identifier of the challenge.
+     * @return An Optional containing the challenge if found, or empty if not found.
+     */
+    public Optional<Challenge> getById(Long id) {
+        return repo.findById(id);
+    }
+
+    /**
+     * Checks if a challenge with the given title exists.
+     *
+     * @param title The title to check for existence.
+     * @return True if a challenge with the title exists, false otherwise.
+     */
+    public boolean titleExists(String title) {
+        return repo.existsByTitleIgnoreCase(title);
+    }
+
+    /**
+     * Checks if a challenge with the given title exists, excluding a specific challenge by ID.
+     *
+     * @param title The title to check for.
+     * @param id    The ID of the challenge to exclude from the check.
+     * @return True if a challenge with the title exists for another challenge, false otherwise.
+     */
+    public boolean titleExistsForOther(String title, Long id) {
+        return repo.existsByTitleIgnoreCaseAndIdNot(title, id);
+    }
+
+    /**
+     * Creates a new challenge based on the provided form data.
+     *
+     * @param form The form containing the challenge data.
+     * @return The created Challenge entity.
+     */
+    @Transactional
+    public Challenge create(ChallengeForm form) {
+        Challenge c = new Challenge(form.getTitle(), form.getDifficulty(), form.getBlurb(), form.getPromptMd());
+        return repo.save(c);
+    }
+
+    /**
+     * Updates an existing challenge with the given ID using the provided form data.
+     *
+     * @param id   The ID of the challenge to update.
+     * @param form The form containing the updated challenge data.
+     * @return An Optional containing the updated challenge if found, or empty if not.
+     */
+    @Transactional
+    public Optional<Challenge> update(Long id, ChallengeForm form) {
+        return repo.findById(id).map(existing -> {
+            existing.setTitle(form.getTitle());
+            existing.setDifficulty(form.getDifficulty());
+            existing.setBlurb(form.getBlurb());
+            existing.setPromptMd(form.getPromptMd());
+            return repo.save(existing);
+        });
+    }
+
+    /**
+     * Deletes a challenge by its ID.
+     *
+     * @param id The ID of the challenge to delete.
+     * @return True if the challenge was deleted, false if it was not found.
+     */
+    @Transactional
+    public boolean delete(Long id) {
+        if (repo.existsById(id)) {
+            repo.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/me/nickhanson/codeforge/utilities/ChallengeRepo.java
+++ b/src/main/java/me/nickhanson/codeforge/utilities/ChallengeRepo.java
@@ -1,10 +1,49 @@
 package me.nickhanson.codeforge.utilities;
 
 import me.nickhanson.codeforge.entity.Challenge;
+import me.nickhanson.codeforge.entity.Difficulty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
+/**
+ * Repository interface for managing Challenge entities.
+ * Provides methods for CRUD operations and custom queries.
+ */
 public interface ChallengeRepo extends JpaRepository<Challenge, Long> {
+    /**
+     * Find a challenge by its title.
+     *
+     * @param title The title of the challenge
+     * @return An Optional containing the Challenge if found, or empty if not found
+     */
     Optional<Challenge> findByTitle(String title);
+
+    /**
+     * Retrieves a paginated list of challenges filtered by difficulty.
+     *
+     * @param difficulty The difficulty level to filter by.
+     * @param pageable   The pagination and sorting information.
+     * @return A page of challenges matching the specified difficulty.
+     */
+    Page<Challenge> findByDifficulty(Difficulty difficulty, Pageable pageable);
+
+    /**
+     * Checks if a challenge with the given title exists (case-insensitive).
+     *
+     * @param title The title to check for.
+     * @return True if a challenge with the title exists, false otherwise.
+     */
+    boolean existsByTitleIgnoreCase(String title);
+
+    /**
+     * Checks if a challenge with the given title exists (case-insensitive), excluding a specific challenge by ID.
+     *
+     * @param title The title to check for.
+     * @param id    The ID of the challenge to exclude from the check.
+     * @return True if a challenge with the title exists (excluding the specified ID), false otherwise.
+     */
+    boolean existsByTitleIgnoreCaseAndIdNot(String title, Long id);
 }

--- a/src/main/java/me/nickhanson/codeforge/web/ChallengeForm.java
+++ b/src/main/java/me/nickhanson/codeforge/web/ChallengeForm.java
@@ -1,0 +1,49 @@
+package me.nickhanson.codeforge.web;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import me.nickhanson.codeforge.entity.Difficulty;
+
+/**
+ * DTO (Data Transfer Object) for creating or updating a Challenge entity.
+ * This class is used to capture and validate user input from forms.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChallengeForm {
+
+    /**
+     * The title of the challenge.
+     * Must not be blank and cannot exceed 100 characters.
+     */
+    @NotBlank
+    @Size(max = 100)
+    private String title;
+
+    /**
+     * The difficulty level of the challenge.
+     * Must not be null.
+     */
+    @NotNull
+    private Difficulty difficulty;
+
+    /**
+     * A short description or summary of the challenge.
+     * Must not be blank.
+     */
+    @NotBlank
+    private String blurb;
+
+    /**
+     * The full prompt for the challenge in Markdown format.
+     * Must not be blank.
+     */
+    @NotBlank
+    private String promptMd;
+}
+

--- a/src/main/java/me/nickhanson/codeforge/web/ChallengesController.java
+++ b/src/main/java/me/nickhanson/codeforge/web/ChallengesController.java
@@ -1,45 +1,211 @@
 package me.nickhanson.codeforge.web;
 
-import me.nickhanson.codeforge.utilities.ChallengeRepo;
+import jakarta.validation.Valid;
 import me.nickhanson.codeforge.entity.Challenge;
+import me.nickhanson.codeforge.entity.Difficulty;
+import me.nickhanson.codeforge.service.ChallengeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.util.List;
-
+/**
+ * Controller class for handling web requests related to Challenges.
+ * Provides endpoints for listing, viewing, creating, updating, and deleting challenges.
+ */
 @Controller
 @RequestMapping("/challenges")
 public class ChallengesController {
-    private static final Logger log = LoggerFactory.getLogger(ChallengesController.class);
-    private final ChallengeRepo repo;
 
-    public ChallengesController(ChallengeRepo repo) {
-        this.repo = repo;
+    private static final Logger log = LoggerFactory.getLogger(ChallengesController.class);
+
+    // Service for managing challenges
+    private final ChallengeService service;
+
+    /**
+     * Constructor for ChallengesController.
+     *
+     * @param service The ChallengeService used for business logic and data access.
+     */
+    public ChallengesController(ChallengeService service) {
+        this.service = service;
     }
 
+    /**
+     * Handles GET requests to list challenges with optional pagination, sorting, and filtering.
+     *
+     * @param page       The page number to retrieve (default is 0).
+     * @param size       The number of items per page (default is 10).
+     * @param sort       The field to sort by (default is "title").
+     * @param dir        The sort direction ("asc" or "desc", default is "asc").
+     * @param difficulty Optional filter by difficulty level.
+     * @param model      The model to populate with data for the view.
+     * @return The name of the view template for the challenge list.
+     */
     @GetMapping
-    public String list(Model model) {
-        List<Challenge> all = repo.findAll();
-        log.info("Rendering challenge list, count={}", all.size());
-        model.addAttribute("challenges", all);
+    public String list(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size,
+            @RequestParam(name = "sort", defaultValue = "title") String sort,
+            @RequestParam(name = "dir", defaultValue = "asc") String dir,
+            @RequestParam(name = "difficulty", required = false) Difficulty difficulty,
+            Model model
+    ) {
+        Sort sortSpec = Sort.by(dir.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC, sort);
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.min(Math.max(size, 1), 50), sortSpec);
+
+        Page<Challenge> pageResult = service.listChallenges(difficulty, pageable);
+
+        log.info("Rendering challenge list page={} size={} sort={} dir={} difficulty={} count={}",
+                page, size, sort, dir, difficulty, pageResult.getNumberOfElements());
+
+        model.addAttribute("challenges", pageResult.getContent());
+        model.addAttribute("page", pageResult);
+        model.addAttribute("currentPage", pageResult.getNumber());
+        model.addAttribute("totalPages", pageResult.getTotalPages());
+        model.addAttribute("pageSize", pageResult.getSize());
+        model.addAttribute("hasPrev", pageResult.hasPrevious());
+        model.addAttribute("hasNext", pageResult.hasNext());
+        model.addAttribute("difficulty", difficulty);
+        model.addAttribute("difficultyValue", difficulty != null ? difficulty.name() : "");
+        model.addAttribute("sort", sort);
+        model.addAttribute("dir", dir);
         return "challenges/list";
     }
 
+    /**
+     * Handles GET requests to view the details of a specific challenge.
+     *
+     * @param id    The ID of the challenge to retrieve.
+     * @param model The model to populate with data for the view.
+     * @return The name of the view template for the challenge detail.
+     */
     @GetMapping("/{id}")
     public String detail(@PathVariable Long id, Model model) {
-        Challenge challenge = repo.findById(id).orElseThrow(() -> {
+        Challenge challenge = service.getById(id).orElseThrow(() -> {
             log.warn("Challenge not found id={}", id);
             return new ResponseStatusException(HttpStatus.NOT_FOUND, "Challenge not found");
         });
         log.info("Rendering challenge detail id={} title={} difficulty={}", id, challenge.getTitle(), challenge.getDifficulty());
         model.addAttribute("challenge", challenge);
         return "challenges/detail";
+    }
+
+    // --- Admin-facing CRUD (basic) ---
+
+    /**
+     * Handles GET requests to display the form for creating a new challenge.
+     *
+     * @param model The model to populate with data for the view.
+     * @return The name of the view template for the new challenge form.
+     */
+    @GetMapping("/new")
+    public String newForm(Model model) {
+        model.addAttribute("form", new ChallengeForm());
+        model.addAttribute("difficulties", Difficulty.values());
+        return "challenges/new";
+    }
+
+    /**
+     * Handles POST requests to create a new challenge.
+     *
+     * @param form   The form data for the new challenge.
+     * @param binding The binding result for validation errors.
+     * @param ra     Redirect attributes for flash messages.
+     * @param model  The model to populate with data for the view in case of errors.
+     * @return A redirect to the challenge detail page if successful, or the new challenge form if validation fails.
+     */
+    @PostMapping
+    public String create(@Valid @ModelAttribute("form") ChallengeForm form,
+                         BindingResult binding,
+                         RedirectAttributes ra,
+                         Model model) {
+        if (service.titleExists(form.getTitle())) {
+            binding.rejectValue("title", "duplicate", "Title must be unique");
+        }
+        if (binding.hasErrors()) {
+            model.addAttribute("difficulties", Difficulty.values());
+            return "challenges/new";
+        }
+        Challenge saved = service.create(form);
+        ra.addFlashAttribute("success", "Challenge created successfully.");
+        return "redirect:/challenges/" + saved.getId();
+    }
+
+    /**
+     * Handles GET requests to display the form for editing an existing challenge.
+     *
+     * @param id    The ID of the challenge to edit.
+     * @param model The model to populate with data for the view.
+     * @return The name of the view template for the edit challenge form.
+     */
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable Long id, Model model) {
+        Challenge challenge = service.getById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Challenge not found"));
+        ChallengeForm form = new ChallengeForm();
+        form.setTitle(challenge.getTitle());
+        form.setDifficulty(challenge.getDifficulty());
+        form.setBlurb(challenge.getBlurb());
+        form.setPromptMd(challenge.getPromptMd());
+        model.addAttribute("form", form);
+        model.addAttribute("difficulties", Difficulty.values());
+        model.addAttribute("challengeId", id);
+        return "challenges/edit";
+    }
+
+    /**
+     * Handles POST requests to update an existing challenge.
+     *
+     * @param id     The ID of the challenge to update.
+     * @param form   The form data for the updated challenge.
+     * @param binding The binding result for validation errors.
+     * @param ra     Redirect attributes for flash messages.
+     * @param model  The model to populate with data for the view in case of errors.
+     * @return A redirect to the challenge detail page if successful, or the edit challenge form if validation fails.
+     */
+    @PostMapping("/{id}")
+    public String update(@PathVariable Long id,
+                         @Valid @ModelAttribute("form") ChallengeForm form,
+                         BindingResult binding,
+                         RedirectAttributes ra,
+                         Model model) {
+        if (service.titleExistsForOther(form.getTitle(), id)) {
+            binding.rejectValue("title", "duplicate", "Title must be unique");
+        }
+        if (binding.hasErrors()) {
+            model.addAttribute("difficulties", Difficulty.values());
+            model.addAttribute("challengeId", id);
+            return "challenges/edit";
+        }
+        Challenge updated = service.update(id, form).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Challenge not found"));
+        ra.addFlashAttribute("success", "Challenge updated successfully.");
+        return "redirect:/challenges/" + updated.getId();
+    }
+
+    /**
+     * Handles POST requests to delete an existing challenge.
+     *
+     * @param id The ID of the challenge to delete.
+     * @param ra Redirect attributes for flash messages.
+     * @return A redirect to the challenge list page.
+     */
+    @PostMapping("/{id}/delete")
+    public String delete(@PathVariable Long id, RedirectAttributes ra) {
+        boolean removed = service.delete(id);
+        if (removed) {
+            ra.addFlashAttribute("success", "Challenge deleted.");
+        } else {
+            ra.addFlashAttribute("error", "Challenge not found.");
+        }
+        return "redirect:/challenges";
     }
 }

--- a/src/main/java/me/nickhanson/codeforge/web/ErrorControllerAdvice.java
+++ b/src/main/java/me/nickhanson/codeforge/web/ErrorControllerAdvice.java
@@ -1,0 +1,64 @@
+package me.nickhanson.codeforge.web;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Global exception handler for the application.
+ * Provides centralized handling of exceptions and maps them to appropriate error views.
+ */
+@ControllerAdvice
+public class ErrorControllerAdvice {
+    private static final Logger log = LoggerFactory.getLogger(ErrorControllerAdvice.class);
+
+    /**
+     * Handles ResponseStatusException and maps it to an appropriate error view.
+     *
+     * @param ex       The ResponseStatusException to handle.
+     * @param model    The model to populate with error details for the view.
+     * @param response The HttpServletResponse to set the HTTP status code.
+     * @return The name of the error view template.
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public String handleStatus(ResponseStatusException ex, Model model, HttpServletResponse response) {
+        int code = ex.getStatusCode().value();
+        HttpStatus status = HttpStatus.resolve(code);
+        if (status == null) {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        response.setStatus(status.value());
+        model.addAttribute("status", status.value());
+        model.addAttribute("error", status.getReasonPhrase());
+        model.addAttribute("message", ex.getReason());
+        if (status == HttpStatus.NOT_FOUND) {
+            log.warn("404 Not Found: {}", ex.getReason());
+            return "error/404";
+        }
+        log.error("HTTP {} {}: {}", status.value(), status.getReasonPhrase(), ex.getReason());
+        return "error/500";
+    }
+
+    /**
+     * Handles generic exceptions and maps them to the 500 error view.
+     *
+     * @param ex       The generic exception to handle.
+     * @param model    The model to populate with error details for the view.
+     * @param response The HttpServletResponse to set the HTTP status code.
+     * @return The name of the 500 error view template.
+     */
+    @ExceptionHandler(Exception.class)
+    public String handleGeneric(Exception ex, Model model, HttpServletResponse response) {
+        log.error("Unhandled exception", ex);
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        model.addAttribute("status", 500);
+        model.addAttribute("error", "Internal Server Error");
+        model.addAttribute("message", ex.getMessage());
+        return "error/500";
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,4 +2,11 @@ INSERT INTO CHALLENGES (TITLE, DIFFICULTY, BLURB, PROMPT_MD)
 VALUES
   ('Two Sum', 'EASY', 'Find two numbers adding up to target.', 'Given an int array nums and int target, return indices of the two numbers such that they add up to target.'),
   ('Valid Parentheses', 'EASY', 'Check if parentheses are balanced.', 'Given a string s containing ''()[]{}'', determine if the input string is valid.'),
-  ('Merge Intervals', 'MEDIUM', 'Merge overlapping intervals.', 'Given an array of intervals where intervals[i] = [starti, endi], merge all overlapping intervals.');
+  ('Merge Intervals', 'MEDIUM', 'Merge overlapping intervals.', 'Given an array of intervals where intervals[i] = [starti, endi], merge all overlapping intervals.'),
+  ('Best Time to Buy and Sell Stock', 'EASY', 'Max profit from single stock trade.', 'Given an array prices where prices[i] is the price of a stock on day i, maximize profit.'),
+  ('Binary Tree Level Order Traversal', 'MEDIUM', 'Traverse levels of a binary tree.', 'Given the root of a binary tree, return the level order traversal of its nodes'' values.'),
+  ('LRU Cache', 'HARD', 'Design a least-recently-used cache.', 'Design a data structure that supports get and put with O(1) average time complexity.'),
+  ('Longest Substring Without Repeating Characters', 'MEDIUM', 'Find longest unique-char substring.', 'Given a string s, find the length of the longest substring without repeating characters.'),
+  ('Climbing Stairs', 'EASY', 'Count ways to climb stairs.', 'Given n, return how many distinct ways you can climb to the top.'),
+  ('Number of Islands', 'MEDIUM', 'Count islands in a grid.', 'Given an m x n 2D binary grid, return the number of islands.'),
+  ('Median of Two Sorted Arrays', 'HARD', 'Find median of two sorted arrays.', 'Given two sorted arrays nums1 and nums2, return the median of the two sorted arrays.');

--- a/src/main/resources/log4j2-spring.xml
+++ b/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level [%t] %c{1.} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="org.springframework" level="info"/>
+    <Logger name="org.hibernate" level="info"/>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>
+

--- a/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/detail.jsp
@@ -5,9 +5,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Challenge Detail</title>
+  <style>
+    .flash-success { background: #e6ffed; border: 1px solid #34c759; padding: .5rem; margin-bottom: 1rem; }
+    .flash-error { background: #ffecec; border: 1px solid #ff3b30; padding: .5rem; margin-bottom: 1rem; }
+  </style>
 </head>
 <body>
-  <p><a href="${pageContext.request.contextPath}/">Home</a> | <a href="${pageContext.request.contextPath}/challenges">All Challenges</a></p>
+  <p><a href="${pageContext.request.contextPath}/">Home</a> | <a href="${pageContext.request.contextPath}/challenges">All Challenges</a> | <a href="${pageContext.request.contextPath}/challenges/${challenge.id}/edit">Edit</a></p>
+
+  <c:if test="${not empty success}">
+    <div class="flash-success">${success}</div>
+  </c:if>
+  <c:if test="${not empty error}">
+    <div class="flash-error">${error}</div>
+  </c:if>
+
   <h1><c:out value="${challenge.title}"/></h1>
   <p>
     <strong>Difficulty:</strong> <c:out value="${challenge.difficulty}"/>

--- a/src/main/webapp/WEB-INF/jsp/challenges/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/edit.jsp
@@ -1,0 +1,50 @@
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Edit Challenge</title>
+</head>
+<body>
+  <p><a href="${pageContext.request.contextPath}/">Home</a> | <a href="${pageContext.request.contextPath}/challenges">All Challenges</a></p>
+  <h1>Edit Challenge</h1>
+
+  <form:form method="post" modelAttribute="form" action="${pageContext.request.contextPath}/challenges/${challengeId}">
+    <div>
+      <label for="title">Title</label><br/>
+      <form:input path="title" id="title" />
+      <div style="color: #b00;"><form:errors path="title"/></div>
+    </div>
+
+    <div>
+      <label for="difficulty">Difficulty</label><br/>
+      <form:select path="difficulty" id="difficulty">
+        <form:options items="${difficulties}" />
+      </form:select>
+      <div style="color: #b00;"><form:errors path="difficulty"/></div>
+    </div>
+
+    <div>
+      <label for="blurb">Summary</label><br/>
+      <form:textarea path="blurb" id="blurb" rows="3" cols="60"/>
+      <div style="color: #b00;"><form:errors path="blurb"/></div>
+    </div>
+
+    <div>
+      <label for="promptMd">Prompt (Markdown)</label><br/>
+      <form:textarea path="promptMd" id="promptMd" rows="10" cols="80"/>
+      <div style="color: #b00;"><form:errors path="promptMd"/></div>
+    </div>
+
+    <div style="margin-top: 1rem;">
+      <button type="submit">Update</button>
+    </div>
+  </form:form>
+
+  <form method="post" action="${pageContext.request.contextPath}/challenges/${challengeId}/delete" style="margin-top: 1rem;">
+    <button type="submit" onclick="return confirm('Delete this challenge?');">Delete</button>
+  </form>
+</body>
+</html>
+

--- a/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/list.jsp
@@ -5,10 +5,39 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Challenges</title>
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/css/challenges.css" />
+  <style>
+    table { border-collapse: collapse; border: 1px solid #000; }
+    .flash-success { background: #e6ffed; border: 1px solid #34c759; padding: .5rem; margin-bottom: 1rem; }
+    .flash-error { background: #ffecec; border: 1px solid #ff3b30; padding: .5rem; margin-bottom: 1rem; }
+  </style>
 </head>
 <body>
   <h1>Challenges</h1>
-  <p><a href="${pageContext.request.contextPath}/">Home</a></p>
+  <p><a href="${pageContext.request.contextPath}/">Home</a> | <a href="${pageContext.request.contextPath}/challenges/new">Create New</a></p>
+
+  <c:if test="${not empty success}">
+    <div class="flash-success">${success}</div>
+  </c:if>
+  <c:if test="${not empty error}">
+    <div class="flash-error">${error}</div>
+  </c:if>
+
+  <form method="get" action="${pageContext.request.contextPath}/challenges" style="margin-bottom: 1rem;">
+    <label for="difficulty">Filter by difficulty:</label>
+    <select name="difficulty" id="difficulty">
+      <option value="" ${empty difficultyValue ? 'selected' : ''}>All</option>
+      <option value="EASY" ${difficultyValue == 'EASY' ? 'selected' : ''}>EASY</option>
+      <option value="MEDIUM" ${difficultyValue == 'MEDIUM' ? 'selected' : ''}>MEDIUM</option>
+      <option value="HARD" ${difficultyValue == 'HARD' ? 'selected' : ''}>HARD</option>
+    </select>
+    <input type="hidden" name="sort" value="${sort}" />
+    <input type="hidden" name="dir" value="${dir}" />
+    <button type="submit">Apply</button>
+    <c:if test="${not empty difficultyValue}">
+      <a href="${pageContext.request.contextPath}/challenges">Clear</a>
+    </c:if>
+  </form>
 
   <c:choose>
     <c:when test="${empty challenges}">
@@ -18,9 +47,15 @@
       <table>
         <thead>
           <tr>
-            <th>ID</th>
-            <th>Title</th>
-            <th>Difficulty</th>
+            <th>
+              <a href="${pageContext.request.contextPath}/challenges?sort=id&dir=${dir == 'asc' ? 'desc' : 'asc'}&difficulty=${difficultyValue}&page=${currentPage}&size=${pageSize}">ID</a>
+            </th>
+            <th>
+              <a href="${pageContext.request.contextPath}/challenges?sort=title&dir=${dir == 'asc' ? 'desc' : 'asc'}&difficulty=${difficultyValue}&page=${currentPage}&size=${pageSize}">Title</a>
+            </th>
+            <th>
+              <a href="${pageContext.request.contextPath}/challenges?sort=difficulty&dir=${dir == 'asc' ? 'desc' : 'asc'}&difficulty=${difficultyValue}&page=${currentPage}&size=${pageSize}">Difficulty</a>
+            </th>
             <th>Blurb</th>
           </tr>
         </thead>
@@ -35,6 +70,31 @@
           </c:forEach>
         </tbody>
       </table>
+
+      <div style="margin-top: 1rem;">
+        <c:if test="${totalPages > 1}">
+          <span>Page ${currentPage + 1} of ${totalPages}</span>
+          <div style="margin-top: 0.5rem;">
+            <c:if test="${hasPrev}">
+              <a href="${pageContext.request.contextPath}/challenges?page=${currentPage - 1}&size=${pageSize}&sort=${sort}&dir=${dir}&difficulty=${difficultyValue}">Prev</a>
+            </c:if>
+            <c:forEach var="i" begin="0" end="${totalPages - 1}">
+              <c:choose>
+                <c:when test="${i == currentPage}">
+                  <strong>[${i + 1}]</strong>
+                </c:when>
+                <c:otherwise>
+                  <a href="${pageContext.request.contextPath}/challenges?page=${i}&size=${pageSize}&sort=${sort}&dir=${dir}&difficulty=${difficultyValue}">${i + 1}</a>
+                </c:otherwise>
+              </c:choose>
+              <c:if test="${i < totalPages - 1}"> </c:if>
+            </c:forEach>
+            <c:if test="${hasNext}">
+              <a href="${pageContext.request.contextPath}/challenges?page=${currentPage + 1}&size=${pageSize}&sort=${sort}&dir=${dir}&difficulty=${difficultyValue}">Next</a>
+            </c:if>
+          </div>
+        </c:if>
+      </div>
     </c:otherwise>
   </c:choose>
 </body>

--- a/src/main/webapp/WEB-INF/jsp/challenges/new.jsp
+++ b/src/main/webapp/WEB-INF/jsp/challenges/new.jsp
@@ -1,0 +1,46 @@
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>New Challenge</title>
+</head>
+<body>
+  <p><a href="${pageContext.request.contextPath}/">Home</a> | <a href="${pageContext.request.contextPath}/challenges">All Challenges</a></p>
+  <h1>Create New Challenge</h1>
+
+  <form:form method="post" modelAttribute="form" action="${pageContext.request.contextPath}/challenges">
+    <div>
+      <label for="title">Title</label><br/>
+      <form:input path="title" id="title" />
+      <div style="color: #b00;"><form:errors path="title"/></div>
+    </div>
+
+    <div>
+      <label for="difficulty">Difficulty</label><br/>
+      <form:select path="difficulty" id="difficulty">
+        <form:options items="${difficulties}" />
+      </form:select>
+      <div style="color: #b00;"><form:errors path="difficulty"/></div>
+    </div>
+
+    <div>
+      <label for="blurb">Summary</label><br/>
+      <form:textarea path="blurb" id="blurb" rows="3" cols="60"/>
+      <div style="color: #b00;"><form:errors path="blurb"/></div>
+    </div>
+
+    <div>
+      <label for="promptMd">Prompt (Markdown)</label><br/>
+      <form:textarea path="promptMd" id="promptMd" rows="10" cols="80"/>
+      <div style="color: #b00;"><form:errors path="promptMd"/></div>
+    </div>
+
+    <div style="margin-top: 1rem;">
+      <button type="submit">Create</button>
+    </div>
+  </form:form>
+</body>
+</html>
+

--- a/src/main/webapp/WEB-INF/jsp/error/404.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error/404.jsp
@@ -1,0 +1,15 @@
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Not Found</title>
+</head>
+<body>
+  <h1>404 — Not Found</h1>
+  <p><strong>${status}</strong> ${error}</p>
+  <p>${message}</p>
+  <p><a href="${pageContext.request.contextPath}/">Back to Home</a></p>
+</body>
+</html>
+

--- a/src/main/webapp/WEB-INF/jsp/error/500.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error/500.jsp
@@ -1,0 +1,15 @@
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Server Error</title>
+</head>
+<body>
+  <h1>500 — Internal Server Error</h1>
+  <p><strong>${status}</strong> ${error}</p>
+  <p>${message}</p>
+  <p><a href="${pageContext.request.contextPath}/">Back to Home</a></p>
+</body>
+</html>
+

--- a/src/main/webapp/css/challenges.css
+++ b/src/main/webapp/css/challenges.css
@@ -1,0 +1,6 @@
+
+table th, table td {
+    padding: 6px;
+    border: 1px solid #000;
+}
+

--- a/src/test/java/me/nickhanson/codeforge/web/ChallengesControllerTest.java
+++ b/src/test/java/me/nickhanson/codeforge/web/ChallengesControllerTest.java
@@ -1,0 +1,143 @@
+package me.nickhanson.codeforge.web;
+
+import me.nickhanson.codeforge.entity.Challenge;
+import me.nickhanson.codeforge.entity.Difficulty;
+import me.nickhanson.codeforge.service.ChallengeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Unit tests for the ChallengesController.
+ * Uses MockMvc to simulate HTTP requests and verify responses.
+ */
+@WebMvcTest(controllers = {ChallengesController.class, ErrorControllerAdvice.class})
+class ChallengesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ChallengeService service;
+
+    /**
+     * Configuration to set up a view resolver for testing.
+     * This allows the tests to verify view names without needing actual JSP files.
+     */
+    @TestConfiguration
+    static class ViewResolverConfig {
+        @Bean
+        InternalResourceViewResolver defaultViewResolver() {
+            InternalResourceViewResolver resolver = new InternalResourceViewResolver();
+            resolver.setPrefix("/WEB-INF/jsp/");
+            resolver.setSuffix(".jsp");
+            return resolver;
+        }
+    }
+
+    /**
+     * Test cases for the ChallengesController.
+     * Each test simulates a specific HTTP request and verifies the response.
+     *
+     * @throws Exception if the request fails.
+     */
+    @Test
+    void list_shouldRenderListJsp() throws Exception {
+        Page<Challenge> empty = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 10), 0);
+        when(service.listChallenges(nullable(Difficulty.class), any())).thenReturn(empty);
+
+        mockMvc.perform(get("/challenges"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("challenges/list"));
+    }
+
+    /**
+     * Test the detail view for a known challenge ID.
+     * Mocks the service to return a specific challenge and verifies the correct view is rendered.
+     * Tests that the detail endpoint renders the "error/404" JSP view for an unknown ID.
+     *
+     * @throws Exception if the request fails.
+     */
+    @Test
+    void detail_unknownId_shouldRender404Jsp() throws Exception {
+        when(service.getById(99L)).thenReturn(Optional.empty());
+        mockMvc.perform(get("/challenges/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(view().name("error/404"));
+    }
+
+    /**
+     * Test the detail view for a known challenge ID.
+     * Mocks the service to return a specific challenge and verifies the correct view is rendered.
+     * Tests that the new form endpoint renders the "challenges/new" JSP view.
+     *
+     * @throws Exception if the request fails.
+     */
+    @Test
+    void newForm_shouldRenderNewJsp() throws Exception {
+        mockMvc.perform(get("/challenges/new"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("challenges/new"));
+    }
+
+    /**
+     * Test creating a new challenge with valid data.
+     * Mocks the service to simulate successful creation and verifies redirection to the detail view.
+     * Tests that a valid create request redirects to the challenge detail page.
+     *
+     * @throws Exception if the request fails.
+     */
+    @Test
+    void create_valid_shouldRedirectToDetail() throws Exception {
+        when(service.titleExists(anyString())).thenReturn(false);
+        Challenge saved = new Challenge("Title", Difficulty.EASY, "blurb", "prompt");
+        saved.setId(123L);
+        when(service.create(any(ChallengeForm.class))).thenReturn(saved);
+
+        mockMvc.perform(post("/challenges")
+                        .param("title", "Unique Title")
+                        .param("difficulty", "EASY")
+                        .param("blurb", "A short summary")
+                        .param("promptMd", "Prompt body"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/challenges/123"))
+                .andExpect(flash().attributeExists("success"));
+    }
+
+    /**
+     * Test creating a new challenge with a duplicate title.
+     * Mocks the service to simulate a duplicate title scenario and verifies the form is re-rendered with errors.
+     * Tests that a create request with a duplicate title returns to the new form with an error.
+     *
+     * @throws Exception if the request fails.
+     */
+    @Test
+    void create_duplicateTitle_shouldReturnNewWithError() throws Exception {
+        when(service.titleExists(anyString())).thenReturn(true);
+
+        mockMvc.perform(post("/challenges")
+                        .param("title", "Duplicate Title")
+                        .param("difficulty", "EASY")
+                        .param("blurb", "A short summary")
+                        .param("promptMd", "Prompt body"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("challenges/new"));
+    }
+}


### PR DESCRIPTION
This pull request introduces a major refactor and expansion of the challenge management functionality in the application. It adds a dedicated service layer, a data transfer object for form handling, and a repository interface with custom queries. The controller is overhauled to support full CRUD operations, pagination, sorting, and filtering for challenges. Additionally, global error handling is centralized for better user feedback. The entity class for challenges is now fully documented for clarity and maintainability.

**Challenge Management Refactor and Expansion**

* Added a new service layer (`ChallengeService`) to encapsulate business logic and CRUD operations for challenges, improving separation of concerns and testability.
* Introduced `ChallengeForm` DTO for validating and transferring challenge data from forms, ensuring robust input validation and simplifying controller logic.
* Created and documented the `ChallengeRepo` repository interface with custom query methods for challenge existence checks, difficulty-based filtering, and case-insensitive title checks.

**Controller Overhaul**

* Refactored `ChallengesController` to use the service layer, support paginated and sortable challenge listing, and implement full CRUD endpoints (create, update, delete) with validation and flash messaging.

**Error Handling Improvements**

* Added a global exception handler (`ErrorControllerAdvice`) to map exceptions to user-friendly error views and set appropriate HTTP status codes.

**Documentation and Minor Enhancements**

* Enhanced Javadoc comments throughout the `Challenge` entity for better maintainability and developer understanding. [[1]](diffhunk://#diff-ff824fae0a91812d02de3885c56995159cea908c818b182cfa85448829f06c9eR10-R94) [[2]](diffhunk://#diff-ff824fae0a91812d02de3885c56995159cea908c818b182cfa85448829f06c9eR106-R111)
* Minor fix in `.githooks/pre-commit` for Maven command usage.