### PR TITLE
feat(config): re-introduce hibernate configuration file for database connection without secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,6 @@ fabric.properties
 # props files that I do not want shared
 https-instance.config
 .idea/copilot.*
-/src/main/resources/hibernate.cfg.xml
 /src/main/resources/cognito.properties
 /src/main/.platform/httpd/conf.d/00_force_https.conf
 /src/main/.platform/hooks/postdeploy/10_cert_setup.sh

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "https://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <!-- JDBC connection (values resolved from System properties for CI; MySQL only) -->
+        <property name="hibernate.connection.driver_class">com.mysql.cj.jdbc.Driver</property>
+        <!-- Use system property hibernate.connection.url or default to local MySQL cf_test_db -->
+        <property name="hibernate.connection.url">
+            jdbc:mysql://${DB_HOST}:3306/${DB_NAME}
+            ?useSSL=false
+            &amp;allowPublicKeyRetrieval=true
+            &amp;serverTimezone=UTC
+            &amp;useUnicode=true
+            &amp;characterEncoding=utf8mb4
+            &amp;connectionCollation=utf8mb4_unicode_ci
+        </property>
+        <property name="hibernate.connection.username">${DB_USER}</property>
+        <property name="hibernate.connection.password">${DB_PASS}</property>
+
+        <!-- Schema handling -->
+
+        <!-- Dialect (explicit MySQL) -->
+        <property name="hibernate.dialect">org.hibernate.dialect.MySQL8Dialect</property>
+
+        <!-- Show SQL while developing -->
+        <property name="hibernate.show_sql">true</property>
+        <property name="hibernate.format_sql">true</property>
+
+        <!-- Entity mappings -->
+        <mapping class="me.nickhanson.codeforge.entity.Challenge"/>
+        <mapping class="me.nickhanson.codeforge.entity.Submission"/>
+        <mapping class="me.nickhanson.codeforge.entity.DrillItem"/>
+
+    </session-factory>
+</hibernate-configuration>


### PR DESCRIPTION
This pull request introduces a new Hibernate configuration file to the project, enabling integration with a MySQL database and mapping core entities for ORM. This is a foundational setup for database connectivity and object-relational mapping.

Hibernate configuration and database setup:

* Added `hibernate.cfg.xml` to configure Hibernate with MySQL, including JDBC connection properties, dialect, and SQL formatting options.
* Mapped the core entities (`Challenge`, `Submission`, `DrillItem`) for Hibernate ORM within the configuration file.